### PR TITLE
Remove lower bound to use global pin

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,5 @@
+azure_core_cpp:
+- 1.12.0
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,5 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
+azure_core_cpp:
+- 1.12.0
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,3 +1,5 @@
+azure_core_cpp:
+- 1.12.0
 c_stdlib:
 - sysroot
 c_stdlib_version:

--- a/.ci_support/migrations/azure_core_cpp1120.yaml
+++ b/.ci_support/migrations/azure_core_cpp1120.yaml
@@ -1,0 +1,21 @@
+migrator_ts: 1718824596
+__migrator:
+  kind: version
+  migration_number: 1
+  bump_number: 1
+  commit_message: Pin azure-core-cpp 1.12.0
+
+azure_core_cpp:
+  - 1.12.0
+azure_identity_cpp:
+  - 1.8.0
+azure_storage_blobs_cpp:
+  - 12.11.0
+azure_storage_common_cpp:
+  - 12.6.0
+azure_storage_files_datalake_cpp:
+  - 12.10.0
+azure_storage_files_shares_cpp:
+  - 12.9.0
+azure_storage_queues_cpp:
+  - 12.2.0

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '10.13'
 MACOSX_SDK_VERSION:
 - '10.13'
+azure_core_cpp:
+- 1.12.0
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -2,6 +2,8 @@ MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
 - '11.0'
+azure_core_cpp:
+- 1.12.0
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,3 +1,5 @@
+azure_core_cpp:
+- 1.12.0
 c_stdlib:
 - vs
 channel_sources:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - cmake
     - ninja
   host:
-    - azure-core-cpp >=1.9.0
+    # azure-core-cpp is pinned in conda-forge-pinning-feedstock
+    - azure-core-cpp
     - openssl  # [not win]
     - wil  # [win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - 0001-remove-wil-from-exported-config.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("azure-identity-cpp", max_pin="x.x.x") }}
 


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

---

We have to remove the lower bound from the recipe in order to use the global pin that conda-smithy will add to the YAML files in `.ci_support/`

xref: https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/6003, https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/6048